### PR TITLE
support multiple targets, use grunt config standards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,6 @@ before_script:
   - npm install -g grunt-cli
 node_js:
   - "0.10"
-  - "0.8"
+  - "0.12"
+  - "iojs"
+

--- a/Readme.md
+++ b/Readme.md
@@ -26,10 +26,7 @@ grunt.initConfig({
         entry: 'app.js',
         out: 'obfuscated.js',
         strings: true,
-        root: __dirname,
-        compressor: {
-          warnings: true
-        }
+        root: __dirname
       }
     }
   }
@@ -40,7 +37,7 @@ grunt.initConfig({
 
 ### `files`
 
-  An array of files to be obfuscated.  This must include every `require()`-ed file in your project.  Wildcards `e.g. "./lib/**/*.js"` are accepted.  
+  An array of files to be obfuscated.  This must include every `require()`-ed file in your project.  Wildcards `e.g. "./lib/**/*.js"` are accepted.
 
 ### `entry`
 
@@ -58,7 +55,7 @@ grunt.initConfig({
 
   The base directory.  Usually `__dirname` works just fine.
 
-## License 
+## License
 
 (The MIT License)
 

--- a/Readme.md
+++ b/Readme.md
@@ -26,7 +26,10 @@ grunt.initConfig({
         entry: 'app.js',
         out: 'obfuscated.js',
         strings: true,
-        root: __dirname
+        root: __dirname,
+        compressor: {
+          warnings: true
+        }
       }
     }
   }

--- a/Readme.md
+++ b/Readme.md
@@ -17,14 +17,18 @@ grunt.loadNpmTasks('grunt-obfuscator');
 
 grunt.initConfig({
   obfuscator: {
-    files: [
-      'app.js',
-      'lib/routes/*.js'
-    ],
-    entry: 'app.js',
-    out: 'obfuscated.js',
-    strings: true,
-    root: __dirname
+    app: {
+      src: [
+        'app.js',
+        'lib/routes/*.js'
+      ],
+      options: {
+        entry: 'app.js',
+        out: 'obfuscated.js',
+        strings: true,
+        root: __dirname
+      }
+    }
   }
 });
 ```

--- a/example/Gruntfile.js
+++ b/example/Gruntfile.js
@@ -10,7 +10,8 @@ module.exports = function (grunt) {
       options: {
         root: __dirname,
         entry: 'app.js',
-        out: 'out.js'
+        out: 'out.js',
+        warnings: true
       }
     }
   });

--- a/example/Gruntfile.js
+++ b/example/Gruntfile.js
@@ -10,8 +10,7 @@ module.exports = function (grunt) {
       options: {
         root: __dirname,
         entry: 'app.js',
-        out: 'out.js',
-        warnings: true
+        out: 'out.js'
       }
     }
   });

--- a/example/Gruntfile.js
+++ b/example/Gruntfile.js
@@ -4,12 +4,14 @@ module.exports = function (grunt) {
 
   grunt.initConfig({
     obfuscator: {
-      files: [
+      src: [
         './*.js'
       ],
-      root: __dirname,
-      entry: 'app.js',
-      out: 'out.js'
+      options: {
+        root: __dirname,
+        entry: 'app.js',
+        out: 'out.js'
+      }
     }
   });
 };

--- a/example/bar.js
+++ b/example/bar.js
@@ -1,4 +1,4 @@
 
 exports.bar = function () {
-  return 'bar'
+  return 'bar';
 };

--- a/example/foo.js
+++ b/example/foo.js
@@ -1,4 +1,4 @@
 
 exports.foo = function () {
-  return 'foo'
+  return 'foo';
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-obfuscator",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Obfuscate nodejs projects via Grunt",
   "keywords": [
     "grunt",

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -1,12 +1,11 @@
 var obfuscator = require('obfuscator'),
+  obfuscatorCompressDefaults = obfuscator.utils.compress.defaults,
   fs = require('fs');
 
 module.exports = function(grunt) {
   grunt.registerMultiTask('obfuscator', 'Obfuscate Node JS projects.', function () {
     var fn = this.async(),
       opts = this.options(),
-      obfuscatorCompressDefaults = obfuscator.utils.compress.defaults,
-      obfuscatorCompressOpts = opts.compressor,
       options = new obfuscator.Options(
         this.filesSrc,
         opts.root,
@@ -15,10 +14,30 @@ module.exports = function(grunt) {
       );
 
     // allow overrides for uglify compressor options.
-    Object.keys(obfuscatorCompressDefaults).forEach(function(key) {
-      obfuscatorCompressOpts[key] = opts[key] || obfuscatorCompressDefaults[key];
+    options.compressor = {};
+    [
+      'sequences',
+      'properties',
+      'dead_code',
+      'drop_debugger',
+      'unsafe',
+      'conditionals',
+      'comparisons',
+      'evaluate',
+      'booleans',
+      'loops',
+      'unused',
+      'hoist_funs',
+      'hoist_vars',
+      'if_return',
+      'join_vars',
+      'cascade',
+      'side_effects',
+      'warnings',
+      'global_defs'
+    ].forEach(function(key) {
+      options.compressor[key] = opts[key] || obfuscatorCompressDefaults[key];
     });
-    options.compressor = obfuscatorCompressOpts;
 
     obfuscator(options, function (err, data) {
       if (err) {

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -1,37 +1,30 @@
 
-var obfuscator = require('obfuscator');
-var fs = require('fs');
+var obfuscator = require('obfuscator'),
+  fs = require('fs');
 
 module.exports = function(grunt) {
-  grunt.registerTask('obfuscator', 'Your task description goes here.', function () {
-    var fn = this.async();
-    var entry = option('entry');
-    var root = option('root');
-    var out = option('out');
-    var strings = option('strings');
-    var files = option('files');
-
-    files = grunt.file.expand(files);
-    var options = new obfuscator.Options(files, root, entry, strings);
-
+  grunt.registerMultiTask('obfuscator', 'Obfuscate Node JS projects.', function () {
+    var fn = this.async(),
+      opts = this.options,
+      options = new Obfuscator.Options(
+        this.filesSrc,
+        opts.root,
+        opts.entry,
+        opts.strings
+      );
+      
     obfuscator(options, function (err, data) {
       if (err) {
-        grunt.log.error(err);
-        return fn(false);
+        return fn(err);
       }
 
-      fs.writeFile(out, data, function (err) {
+      fs.writeFile(opts.out, data, function (err) {
         if (err) {
-          grunt.log.error(err);
-          return fn(false);
+          return fn(err);
         }
 
         fn();
       });
     });
   });
-
-  function option(name) {
-    return grunt.config('obfuscator.' + name);
-  }
 };

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -1,4 +1,3 @@
-
 var obfuscator = require('obfuscator'),
   fs = require('fs');
 
@@ -6,13 +5,21 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('obfuscator', 'Obfuscate Node JS projects.', function () {
     var fn = this.async(),
       opts = this.options(),
+      obfuscatorCompressDefaults = obfuscator.utils.compress.defaults,
+      obfuscatorCompressOpts = opts.compressor,
       options = new obfuscator.Options(
         this.filesSrc,
         opts.root,
         opts.entry,
         opts.strings
       );
-      
+
+    // allow overrides for uglify compressor options.
+    Object.keys(obfuscatorCompressDefaults).forEach(function(key) {
+      obfuscatorCompressOpts[key] = opts[key] || obfuscatorCompressDefaults[key];
+    });
+    options.compressor = obfuscatorCompressOpts;
+
     obfuscator(options, function (err, data) {
       if (err) {
         return fn(err);

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -36,7 +36,11 @@ module.exports = function(grunt) {
       'warnings',
       'global_defs'
     ].forEach(function(key) {
-      options.compressor[key] = opts[key] || obfuscatorCompressDefaults[key];
+      if(opts.hasOwnProperty(key)) {
+      	options.compressor[key] = opts[key];
+      } else {
+      	options.compressor[key] = obfuscatorCompressDefaults[key];
+      }
     });
 
     obfuscator(options, function (err, data) {

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -6,7 +6,7 @@ module.exports = function(grunt) {
   grunt.registerMultiTask('obfuscator', 'Obfuscate Node JS projects.', function () {
     var fn = this.async(),
       opts = this.options,
-      options = new Obfuscator.Options(
+      options = new obfuscator.Options(
         this.filesSrc,
         opts.root,
         opts.entry,

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -5,7 +5,7 @@ var obfuscator = require('obfuscator'),
 module.exports = function(grunt) {
   grunt.registerMultiTask('obfuscator', 'Obfuscate Node JS projects.', function () {
     var fn = this.async(),
-      opts = this.options,
+      opts = this.options(),
       options = new obfuscator.Options(
         this.filesSrc,
         opts.root,


### PR DESCRIPTION
These changes use registerMultiTask instead of registerTask to support multiple targets.  The changes also leverage src and options to better conform with the recommendations in grunt's documentation. This should solve issues 4 & 6 (I think).
